### PR TITLE
Improve CLI error messages associated with opening train/test file

### DIFF
--- a/crates/cli/main.rs
+++ b/crates/cli/main.rs
@@ -178,7 +178,7 @@ fn main() {
 		Subcommand::Serve(args) => self::serve::serve(*args),
 	};
 	if let Err(error) = result {
-		eprintln!("{}: {}", "error".red().bold(), error);
+		eprintln!("{}: {:#}", "error".red().bold(), error);
 		std::process::exit(1);
 	}
 }

--- a/crates/table/load.rs
+++ b/crates/table/load.rs
@@ -1,5 +1,5 @@
 use super::*;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use std::{
 	collections::{BTreeMap, BTreeSet},
 	path::Path,
@@ -71,7 +71,9 @@ impl Table {
 		options: FromCsvOptions,
 		handle_progress_event: &mut impl FnMut(LoadProgressEvent),
 	) -> Result<Table> {
-		let len = std::fs::metadata(path)?.len();
+		let len = std::fs::metadata(path)
+			.with_context(|| format!("Unable to open the input file \"{}\"", path.display()))?
+			.len();
 		Table::from_csv(
 			&mut csv::Reader::from_path(path)?,
 			len,


### PR DESCRIPTION
This PR adds the filename to the CLI outputs when an error is encountered opening the input file(s).

![error_msg](https://user-images.githubusercontent.com/1651814/157474291-ffc34bb7-eadd-4002-bfb8-88776421a156.png)


fixes #113
