### PR TITLE
Update Elixir HTTPoison dependency

### DIFF
--- a/languages/elixir/mix.exs
+++ b/languages/elixir/mix.exs
@@ -8,7 +8,7 @@ defmodule ModelFox.MixProject do
       deps: [
         {:ex_doc, "~> 0.23", only: :dev, runtime: false},
         {:dialyxir, "~> 1.0", only: :dev, runtime: false},
-        {:httpoison, "~> 1.7"},
+        {:httpoison, "~> 2.2.1"},
         {:jason, "~> 1.2"}
       ],
       docs: [


### PR DESCRIPTION
## What
The current version of HttpPoison is outdated and now causing conflicts with other dependencies. 

## How
Update the HttpPoison dependency. It is only used in one spot in the code for a single request. 