### PR TITLE
Update link from unofficial nixos wiki to official one

### DIFF
--- a/crates/tree/benchmarks/README.md
+++ b/crates/tree/benchmarks/README.md
@@ -2,7 +2,7 @@
 
 To run the benchmarks:
 
-1. Install the nix package manager with flake support: https://nixos.wiki/wiki/Flakes.
+1. Install the nix package manager with flake support: https://wiki.nixos.org/wiki/Flakes.
 
 2. Clone the modelfox repo and `cd` into it: `git clone git@github.com:modelfoxdotdev/modelfox && cd modelfox`.
 


### PR DESCRIPTION
The README references the old, unofficial NixOS wiki. This PR updates the links to point to the new official NixOS wiki source, which will be more properly maintained in the future. It's very much a Fandom wiki situation.